### PR TITLE
Add sensible-editor support

### DIFF
--- a/chronicle.sh
+++ b/chronicle.sh
@@ -20,7 +20,10 @@ COLOR="TRUE"
 
 command="$1"
 
-
+which sensible-editor >/dev/null 2>&1;
+if [[ "$?" -eq 0 ]]; then
+    EDITOR="sensible-editor";
+fi
 
 # ---[ Information ]--------------------------------------------------------- #
 

--- a/chronicle.sh
+++ b/chronicle.sh
@@ -3,7 +3,9 @@ VERSION="0.1.1"
 
 SYSTEM_CONFIG="/etc/chronicle.cfg"
 USER_CONFIG="$HOME/.chronicle.cfg"
-EDITOR="vim + +startinsert"
+if [ "$EDITOR" -eq ]; then
+    EDITOR="vim + +startinsert"
+fi
 
 CHRONICLE_DIR="$HOME/.chronicle"
 DATE_FORMAT="%Y/%m/%d/%H:%M:%S"


### PR DESCRIPTION
On many Linux distributions, `sensible-editor` is installed, which is a command-line application that stars the users preferred editor.

This pull request adds support for it - if it is available - by setting the local variable `EDITOR` to `sensible-editor` if it exists.

Further work in this area could include supporting the environment variable `EDITOR`, which is set on some systems that don't have `sensible-editor` (currently chronicle overwrites this environment variable if it is passed in).