### PR TITLE
Respect CHRONICLE_DIR environment variable

### DIFF
--- a/chronicle.sh
+++ b/chronicle.sh
@@ -7,7 +7,7 @@ if [ "$EDITOR" -eq ]; then
     EDITOR="vim + +startinsert"
 fi
 
-CHRONICLE_DIR="$HOME/.chronicle"
+${CHRONICLE_DIR:="$HOME/.chronicle"}
 DATE_FORMAT="%Y/%m/%d/%H:%M:%S"
 
 TMP_ENTRY="/tmp/chronicle.cfg"


### PR DESCRIPTION
The rest of the settings could also be set as default, but this one is
explicit about chronicle so is less surprising.

This way, it allows me setting the chronicle_dir within a project using `direnv`.